### PR TITLE
implement send method on RemoteAddr

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ ndarray = { version = "0.15.4", optional = true, features = ["serde"]}
 trust-dns-proto = { version = "0.22.0", default-features = false, features = ["tokio-runtime"] }
 trust-dns-resolver = { version = "0.22.0", default-features = false, features = ["tokio-runtime", "system-config"] }
 derive_more = "0.99"
+oneshot = "0.1.5"
 
 [patch.crates-io]
 actix-telepathy = { path = "." }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,6 @@ ndarray = { version = "0.15.4", optional = true, features = ["serde"]}
 trust-dns-proto = { version = "0.22.0", default-features = false, features = ["tokio-runtime"] }
 trust-dns-resolver = { version = "0.22.0", default-features = false, features = ["tokio-runtime", "system-config"] }
 derive_more = "0.99"
-oneshot = "0.1.5"
 
 [patch.crates-io]
 actix-telepathy = { path = "." }

--- a/src/cluster/mod.rs
+++ b/src/cluster/mod.rs
@@ -120,7 +120,6 @@ impl Cluster {
 }
 
 // Singleton
-
 impl Default for Cluster {
     fn default() -> Self {
         let ip_addr = "127.0.0.1:8000";

--- a/src/remote/addr/mod.rs
+++ b/src/remote/addr/mod.rs
@@ -1,7 +1,7 @@
+use std::any::{Any, TypeId};
 use std::hash::{Hash, Hasher};
 use std::net::SocketAddr;
 use std::str::FromStr;
-use std::any::{TypeId, Any};
 
 use actix::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -95,15 +95,12 @@ impl RemoteAddr {
         unimplemented!("So far, it is not possible to use this method!")
     }
 
-    pub fn send<T, R, H>(
-        &self,
-        msg: T,
-        c: &Addr<H>,
-    ) -> Receiver<Box<dyn Any + Send>>
-    where T: RemoteMessage + Serialize,
-          R: RemoteMessage + Send + 'static,
-          H: Handler<R> + Handler<ResponseSubscribe>,
-          <H as Actor>::Context: ToEnvelope<H, ResponseSubscribe>,
+    pub fn send<T, R, H>(&self, msg: T, c: &Addr<H>) -> Receiver<Box<dyn Any + Send>>
+    where
+        T: RemoteMessage + Serialize,
+        R: RemoteMessage + Send + 'static,
+        H: Handler<R> + Handler<ResponseSubscribe>,
+        <H as Actor>::Context: ToEnvelope<H, ResponseSubscribe>,
     {
         let (tx, rx) = oneshot::channel();
         c.do_send(ResponseSubscribe(TypeId::of::<R>(), tx));

--- a/src/remote/addr/mod.rs
+++ b/src/remote/addr/mod.rs
@@ -12,6 +12,8 @@ use crate::remote::{AddrRepresentation, RemoteMessage, RemoteWrapper};
 use crate::{NetworkInterface, WrappedClusterMessage};
 use actix::dev::ToEnvelope;
 
+use tokio::sync::oneshot::{self, Receiver};
+
 pub mod resolver;
 #[cfg(test)]
 mod tests;
@@ -97,7 +99,7 @@ impl RemoteAddr {
         &self,
         msg: T,
         c: &Addr<H>,
-    ) -> oneshot::Receiver<Box<dyn Any + Send>>
+    ) -> Receiver<Box<dyn Any + Send>>
     where T: RemoteMessage + Serialize,
           R: RemoteMessage + Send + 'static,
           H: Handler<R> + Handler<ResponseSubscribe>,

--- a/src/remote/addr/mod.rs
+++ b/src/remote/addr/mod.rs
@@ -1,11 +1,13 @@
 use std::hash::{Hash, Hasher};
 use std::net::SocketAddr;
 use std::str::FromStr;
+use std::any::{TypeId, Any};
 
 use actix::prelude::*;
 use serde::{Deserialize, Serialize};
 
 use crate::codec::ClusterMessage;
+use crate::remote::ResponseSubscribe;
 use crate::remote::{AddrRepresentation, RemoteMessage, RemoteWrapper};
 use crate::{NetworkInterface, WrappedClusterMessage};
 use actix::dev::ToEnvelope;
@@ -91,10 +93,20 @@ impl RemoteAddr {
         unimplemented!("So far, it is not possible to use this method!")
     }
 
-    pub fn send<T: RemoteMessage + Serialize>(&self, _msg: T) {
-        unimplemented!(
-            "So far, it is not possible to receive responses from remote destinations as futures!"
-        )
+    pub fn send<T, R, H>(
+        &self,
+        msg: T,
+        c: &Addr<H>,
+    ) -> oneshot::Receiver<Box<dyn Any + Send>>
+    where T: RemoteMessage + Serialize,
+          R: RemoteMessage + Send + 'static,
+          H: Handler<R> + Handler<ResponseSubscribe>,
+          <H as Actor>::Context: ToEnvelope<H, ResponseSubscribe>,
+    {
+        let (tx, rx) = oneshot::channel();
+        c.do_send(ResponseSubscribe(TypeId::of::<R>(), tx));
+        self.do_send(msg);
+        rx
     }
 
     pub fn wait_send<T: RemoteMessage + Serialize>(

--- a/src/remote/addr/tests.rs
+++ b/src/remote/addr/tests.rs
@@ -1,16 +1,19 @@
 use crate::prelude::*;
-use crate::{AddrRepresentation, AddrRequest, AddrResolver, AddrResponse};
+use crate::{AddrRepresentation, AddrRequest, AddrResolver, AddrResponse, ResponseSubscribe};
+use oneshot::Sender;
 use actix::prelude::*;
 use actix_broker::BrokerSubscribe;
 use actix_telepathy_derive::{RemoteActor, RemoteMessage};
 use port_scanner::request_open_port;
 use rayon::iter::IntoParallelRefIterator;
 use rayon::iter::ParallelIterator;
+use rayon::iter::IndexedParallelIterator;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::net::SocketAddr;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, mpsc};
 use std::time::Duration;
+use std::any::{Any, TypeId};
 use tokio::time::sleep;
 
 #[derive(RemoteMessage, Serialize, Deserialize)]
@@ -187,4 +190,150 @@ impl Handler<ClusterLog> for OwnListenerGossipIntroduction {
             _ => (),
         }
     }
+}
+
+#[derive(RemoteMessage, Serialize, Deserialize)]
+struct ResponseTestMessage {}
+
+#[derive(RemoteMessage, Serialize, Deserialize)]
+struct ResponseTest(pub String);
+
+#[derive(Debug)]
+enum InternalError {
+    Timeout,
+}
+
+#[derive(Message)]
+#[rtype(result = "Result<(), InternalError>")]
+struct InternalTrigger();
+
+#[derive(RemoteActor)]
+#[remote_messages(ResponseTestMessage, ResponseTest)]
+struct SendTestActor {
+    members: Arc<Mutex<Vec<RemoteAddr>>>,
+    subscription_senders: HashMap<TypeId, Sender<Box<dyn Any + Send + 'static>>>,
+}
+
+impl SendTestActor {
+    pub fn new() -> Self {
+        Self {
+            members: Arc::new(Mutex::new(vec![])),
+            subscription_senders: HashMap::new(),
+        }
+    }
+}
+
+impl Actor for SendTestActor {
+    type Context = Context<Self>;
+
+    fn started(&mut self, ctx: &mut Context<Self>) {
+        self.register(ctx.address().recipient());
+        self.subscribe_system_async::<ClusterLog>(ctx);
+    }
+}
+
+impl Handler<InternalTrigger> for SendTestActor {
+    type Result = ResponseFuture<Result<(), InternalError>>;
+    fn handle(&mut self, _: InternalTrigger, ctx: &mut Context<Self>) -> Self::Result {
+        let self_addr = ctx.address();
+        let members = self.members.clone();
+        Box::pin(async move {
+            for remote_addr in members.lock().unwrap().iter() {
+                let future = remote_addr.send::<_, ResponseTest, _>(ResponseTestMessage{}, &self_addr.clone());
+                let res = tokio::time::timeout(Duration::from_secs(2), future).await.unwrap();
+                res.map_err(|_| InternalError::Timeout)?;
+            }
+            Ok(())
+        })
+    }
+}
+
+impl Handler<ResponseTestMessage> for SendTestActor {
+    type Result = ResponseFuture<()>;
+    fn handle(&mut self, _: ResponseTestMessage, _: &mut Context<Self>) -> Self::Result {
+        let members = self.members.clone();
+        Box::pin(async move {
+            let members = members.lock().unwrap();
+            for remote_addr in members.iter() {
+                remote_addr.do_send(ResponseTest("Hello from the other side".to_string()));
+            }
+        })
+    }
+}
+
+impl Handler<ResponseSubscribe> for SendTestActor {
+    type Result = ();
+    fn handle(&mut self, ResponseSubscribe(id, tx): ResponseSubscribe, _: &mut Context<Self>) {
+        self.subscription_senders.insert(id, tx);
+    }
+}
+
+impl Handler<ResponseTest> for SendTestActor {
+    type Result = ();
+    fn handle(&mut self, msg: ResponseTest, _: &mut Context<Self>) {
+        let tx = self.subscription_senders.remove(&TypeId::of::<ResponseTest>());
+        if let Some(tx) = tx {
+            tx.send(Box::new(msg)).unwrap();
+        }
+    }
+}
+
+impl ClusterListener for SendTestActor {}
+
+impl Handler<ClusterLog> for SendTestActor {
+    type Result = ResponseFuture<()>;
+    fn handle(&mut self, msg: ClusterLog, _: &mut Context<Self>) -> Self::Result {
+        let members = self.members.clone();
+        Box::pin(async move {
+            match msg {
+                ClusterLog::NewMember(_addr, mut remote_addr) => {
+                    remote_addr.change_id(Self::ACTOR_ID.to_string());
+                    members.lock().unwrap().push(remote_addr);
+                },
+                _ => (),
+            }
+        })
+    }
+}
+
+#[test]
+fn test_send_with_response() {
+    let _ = env_logger::builder().is_test(true).try_init();
+    let ip1: SocketAddr = format!("127.0.0.1:{}", request_open_port().unwrap_or(8000))
+        .parse()
+        .unwrap();
+    let ip2: SocketAddr = format!("127.0.0.1:{}", request_open_port().unwrap_or(8000))
+        .parse()
+        .unwrap();
+    let arr = [
+        (ip1, vec![ip2]),
+        (ip2, vec![]),
+    ];
+    let (tx, rx) = mpsc::channel();
+    let tx = Arc::new(Mutex::new(tx));
+    arr.par_iter()
+        .enumerate()
+        .for_each(|(i, (ip, vec))| match i {
+            0 => test_start_actor(*ip, vec.clone()),
+            1 => test_send_trigger(*ip, vec.clone(), tx.clone()),
+            _ => (),
+        });
+    if let Err(err) = rx.try_recv().unwrap() {
+        panic!("Error occured: {:?}", err);
+    }
+}
+
+#[actix_rt::main]
+async fn test_send_trigger(addr: SocketAddr, seeds: Vec<SocketAddr>, r: Arc<Mutex<mpsc::Sender<Result<(), InternalError>>>>) {
+    let _cluster = Cluster::new(addr, seeds);
+    let actor = SendTestActor::new().start();
+    sleep(Duration::from_millis(300)).await;
+    r.lock().unwrap().send(actor.send(InternalTrigger()).await.unwrap()).unwrap();
+}
+
+#[actix_rt::main]
+async fn test_start_actor(addr: SocketAddr, seeds: Vec<SocketAddr>) {
+    let _cluster = Cluster::new(addr, seeds);
+    let _actor = SendTestActor::new().start();
+    sleep(Duration::from_millis(500)).await;
 }

--- a/src/remote/addr/tests.rs
+++ b/src/remote/addr/tests.rs
@@ -1,6 +1,5 @@
 use crate::prelude::*;
 use crate::{AddrRepresentation, AddrRequest, AddrResolver, AddrResponse, ResponseSubscribe};
-use oneshot::Sender;
 use actix::prelude::*;
 use actix_broker::BrokerSubscribe;
 use actix_telepathy_derive::{RemoteActor, RemoteMessage};
@@ -15,6 +14,7 @@ use std::sync::{Arc, Mutex, mpsc};
 use std::time::Duration;
 use std::any::{Any, TypeId};
 use tokio::time::sleep;
+use tokio::sync::oneshot::Sender;
 
 #[derive(RemoteMessage, Serialize, Deserialize)]
 struct TestMessage {}

--- a/src/remote/message.rs
+++ b/src/remote/message.rs
@@ -2,7 +2,7 @@ use crate::{CustomSerialization, NetworkInterface, RemoteAddr};
 use actix::prelude::*;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
-use oneshot::Sender;
+use tokio::sync::oneshot::Sender;
 use std::any::{Any, TypeId};
 
 /// Wrapper for messages to be sent to remote actor

--- a/src/remote/message.rs
+++ b/src/remote/message.rs
@@ -2,6 +2,8 @@ use crate::{CustomSerialization, NetworkInterface, RemoteAddr};
 use actix::prelude::*;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
+use oneshot::Sender;
+use std::any::{Any, TypeId};
 
 /// Wrapper for messages to be sent to remote actor
 #[derive(Message, Serialize, Deserialize)]
@@ -67,3 +69,7 @@ where
 
     fn set_source(&mut self, source: Addr<NetworkInterface>);
 }
+
+#[derive(Message)]
+#[rtype("()")]
+pub struct ResponseSubscribe(pub TypeId, pub Sender<Box<dyn Any + Send>>);

--- a/src/remote/message.rs
+++ b/src/remote/message.rs
@@ -1,9 +1,9 @@
 use crate::{CustomSerialization, NetworkInterface, RemoteAddr};
 use actix::prelude::*;
 use serde::{Deserialize, Serialize};
-use uuid::Uuid;
-use tokio::sync::oneshot::Sender;
 use std::any::{Any, TypeId};
+use tokio::sync::oneshot::Sender;
+use uuid::Uuid;
 
 /// Wrapper for messages to be sent to remote actor
 #[derive(Message, Serialize, Deserialize)]

--- a/src/remote/mod.rs
+++ b/src/remote/mod.rs
@@ -6,5 +6,5 @@ mod tests;
 
 pub use self::actor::RemoteActor;
 pub use self::addr::{AnyAddr, RemoteAddr};
-pub use self::message::{RemoteMessage, RemoteWrapper};
+pub use self::message::{RemoteMessage, RemoteWrapper, ResponseSubscribe};
 pub use addr::resolver::{AddrRepresentation, AddrRequest, AddrResolver, AddrResponse};


### PR DESCRIPTION
Scheme is the following:
![](https://www.plantuml.com/plantuml/png/SoWkIImgAStDuOfsD8nLqBDJY7RCYrMmKYXEpKjHAAc02ElgWiIDuEAvgSN5YUcfN62rDheeSaMfnGNvUSLWIQY1Xa19e7X9QL4UJAj2MMOYo7W7e1QWxG00)
*A1* is actor calling `send`. *An* is actor corresponding to `H` generic argument in `send`. It must implement `ResponseSubscribe` and handle response type requested by *A1*. *A2* is remote actor