### PR TITLE
Warning actor id non existent

### DIFF
--- a/src/remote/addr/resolver.rs
+++ b/src/remote/addr/resolver.rs
@@ -149,9 +149,11 @@ impl Handler<RemoteWrapper> for AddrResolver {
     type Result = ();
 
     fn handle(&mut self, msg: RemoteWrapper, _ctx: &mut Context<Self>) -> Self::Result {
-        let recipient = self.resolve_rec_from_addr_representation(msg.destination.id.clone())
-            .unwrap_or_else(|_| panic!("Could not resolve Recipient '{}' for RemoteMessage. Is this receiver a RemoteActor?", msg.identifier));
-        recipient.do_send(msg);
+        if let Ok(recipient) = self.resolve_rec_from_addr_representation(msg.destination.id.clone()) {
+            recipient.do_send(msg);
+        } else {
+            warn!("Could not resolve Recipient '{}' for RemoteMessage. Is this receiver a RemoteActor? Message is abandoned.", msg.identifier);
+        }
     }
 }
 


### PR DESCRIPTION
solves #85 

Write a warning if `ACTOR_ID` does not exist instead of panic.