### PR TITLE
bump dependencies and release 0.7.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -93,9 +93,15 @@ jobs:
         with:
           path: target
           key: '${{ runner.os }}-cargo-build-target-${{ hashFiles(''**/Cargo.lock'') }}'
-      - uses: actions-rs/cargo@v1
-        with:
-          command: package
+      - name: Publish actix_telepathy_derive (if not already published)
+        run: |
+          VERSION=$(cargo metadata --no-deps --manifest-path actix-telepathy-derive/Cargo.toml --format-version 1 | jq -r '.packages[0].version')
+          if curl -sf "https://crates.io/api/v1/crates/actix_telepathy_derive/${VERSION}" > /dev/null; then
+            echo "actix_telepathy_derive ${VERSION} already published, skipping"
+          else
+            cargo publish --token ${{ secrets.CRATES_TOKEN }} --manifest-path actix-telepathy-derive/Cargo.toml
+            sleep 20 # wait for actix_telepathy_derive to propagate on crates.io
+          fi
       - uses: actions-rs/cargo@v1
         with:
           command: publish

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "actix-telepathy"
-version = "0.6.1"
+version = "0.7.0"
 authors = ["wenig <info@pwenig.de>"]
-edition = "2018"
+edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/wenig/actix-telepathy/"
 readme = "README.md"
@@ -32,33 +32,31 @@ futures-sink = "0.3.21"
 testing_logger = "0.1.1"
 
 [dependencies]
-actix_telepathy_derive = { version = "0.3.4", optional = true }
+actix_telepathy_derive = { version = "0.4.0", optional = true }
 
 log = "0.4"
 env_logger = "0.11"
 byteorder = "1.3"
-bytes = "1"
+bytes = "1.11.1"
 actix = "=0.13.5"
 actix-broker = "0.4.3"
 tokio = { version = "1.33", features = ["io-util", "sync"] }
 tokio-util = { version = "0.7", features = ["codec"] }
 tokio-stream = { version = "0.1", features = ["net"]}
 futures = "0.3"
-rand = "0.8"
+rand = "0.10.0"
 uuid = { version = "1.0", features = ["v4", "serde"] }
 once_cell = "1.5.2"
 parking_lot = "0.12"
 
 serde = { version = "1.0", features = ["derive"] }
 serde_derive = "1.0"
-flexbuffers = "2.0.0"
-
-ndarray = { version = "0.15.4", optional = true, features = ["serde"]}
+flexbuffers = "25.12.19"
 
 # dns resolver
-trust-dns-proto = { version = "0.23.1", default-features = false, features = ["tokio-runtime"] }
-trust-dns-resolver = { version = "0.23.1", default-features = false, features = ["tokio-runtime", "system-config"] }
-derive_more = "0.99"
+hickory-proto = { version = "0.25.2" }
+hickory-resolver = { version = "0.25.2" }
+derive_more = { version = "2.1.1", features = ["full"] }
 
 [patch.crates-io]
 actix-telepathy = { path = "." }

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![crates.io](https://img.shields.io/crates/v/actix-telepathy?label=latest)](https://crates.io/crates/actix-telepathy)
 ![Tests on main](https://github.com/wenig/actix-telepathy/workflows/Rust/badge.svg)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Dependency Status](https://deps.rs/crate/actix-telepathy/0.6.1/status.svg)](https://deps.rs/crate/actix-telepathy/0.6.1)
+[![Dependency Status](https://deps.rs/crate/actix-telepathy/0.7.0/status.svg)](https://deps.rs/crate/actix-telepathy/0.7.0)
 ![Downloads](https://img.shields.io/crates/d/actix-telepathy.svg)
 
 # Actix-Telepathy
@@ -19,6 +19,8 @@ Inspired by [actix-remote](https://github.com/actix/actix-remote) and [Akka Clus
 | 0.13  | 0.5        | 0.3               |
 | 0.13.1  | 0.6.0        | 0.3.4               |
 | 0.13.5  | 0.6.1        | 0.3.4               |
+| 0.13.5  | 0.6.2        | 0.3.4               |
+| 0.13.5  | 0.7.0        | 0.4.0               |
 
 ## Tests
 
@@ -64,7 +66,7 @@ Ideas and discussion on how to implement a remote response and using the `send` 
 ```toml
 [dependencies]
 actix = "0.13.1"
-actix-telepathy = "0.6.1"
+actix-telepathy = "0.7.0"
 ```
 
 ### main.rs

--- a/actix-telepathy-derive/Cargo.toml
+++ b/actix-telepathy-derive/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "actix_telepathy_derive"
-version = "0.3.4"
+version = "0.4.0"
 authors = ["wenig <info@pwenig.de>"]
-edition = "2018"
+edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/wenig/actix-telepathy/"
 readme = "README.md"

--- a/actix-telepathy-derive/src/remote_actor.rs
+++ b/actix-telepathy-derive/src/remote_actor.rs
@@ -2,7 +2,7 @@ use proc_macro::TokenStream;
 use quote::quote;
 use syn::__private::Span;
 use syn::parse::Parser;
-use syn::{parse_macro_input, DeriveInput, Result};
+use syn::{DeriveInput, Result, parse_macro_input};
 type AttributeArgs = syn::punctuated::Punctuated<syn::Meta, syn::Token![,]>;
 
 const REMOTE_MESSAGES: &str = "remote_messages";
@@ -92,7 +92,7 @@ fn get_message_types_attr(ast: &DeriveInput, ident: &str) -> Result<Vec<Option<s
                     return Err(syn::Error::new_spanned(
                         attr,
                         format!("The correct syntax is #[{}(Message, Message, ...)]", ident),
-                    ))
+                    ));
                 }
             };
             Ok(args.iter().map(|m| meta_item_to_struct(m).ok()).collect())
@@ -112,7 +112,7 @@ fn get_message_types_attr(ast: &DeriveInput, ident: &str) -> Result<Vec<Option<s
 
 fn meta_item_to_struct(meta_item: &syn::Meta) -> syn::Result<syn::Type> {
     match meta_item {
-        syn::Meta::Path(ref path) => match path.get_ident() {
+        syn::Meta::Path(path) => match path.get_ident() {
             Some(ident) => syn::parse_str::<syn::Type>(&ident.to_string())
                 .map_err(|_| syn::Error::new_spanned(ident, "Expect Message")),
             None => Err(syn::Error::new_spanned(path, "Expect Message")),

--- a/actix-telepathy-derive/src/remote_message.rs
+++ b/actix-telepathy-derive/src/remote_message.rs
@@ -3,7 +3,7 @@ use proc_macro::TokenStream;
 use quote::quote;
 use serde_derive::{Deserialize, Serialize};
 use std::fs::File;
-use syn::{parse_macro_input, DeriveInput, Result};
+use syn::{DeriveInput, Result, parse_macro_input};
 
 const TELEPATHY_CONFIG_FILE: &str = "telepathy.yaml";
 const WITH_SOURCE: &str = "with_source";
@@ -28,7 +28,7 @@ fn load_config_yaml() -> Config {
             serde_yaml::from_reader(file_reader).expect("Config file is no valid YAML")
         }
         Err(e) => {
-            error!("{}, using default Config", e.to_string());
+            error!("{}, using default Config", e);
             Config::default()
         }
     }

--- a/src/cluster/connector/gossip.rs
+++ b/src/cluster/connector/gossip.rs
@@ -68,16 +68,16 @@ impl Gossip {
             node.socket_addr,
             node.network_interface.expect("Empty network interface"),
         );
-        debug!(target: &self.own_addr.to_string(), "Member {} added!", node.socket_addr.to_string());
+        debug!(target: &self.own_addr.to_string(), "Member {} added!", node.socket_addr);
     }
 
     fn remove_member(&mut self, addr: SocketAddr) {
         self.members.remove(&addr);
-        debug!(target: &self.own_addr.to_string(), "Member {} removed", addr.to_string());
+        debug!(target: &self.own_addr.to_string(), "Member {} removed", addr);
     }
 
     fn ignite_member_up(&self, new_addr: SocketAddr) {
-        debug!(target: &self.own_addr.to_string(), "Igniting member up {}", new_addr.to_string());
+        debug!(target: &self.own_addr.to_string(), "Igniting member up {}", new_addr);
         self.gossip_member_event(
             new_addr,
             GossipEvent::Join,
@@ -86,7 +86,7 @@ impl Gossip {
     }
 
     fn ignite_member_down(&self, leaving_addr: SocketAddr) {
-        debug!(target: &self.own_addr.to_string(), "Igniting member down {}", leaving_addr.to_string());
+        debug!(target: &self.own_addr.to_string(), "Igniting member down {}", leaving_addr);
         self.gossip_member_event(
             leaving_addr,
             GossipEvent::Leave,
@@ -95,7 +95,7 @@ impl Gossip {
     }
 
     fn gossip_member_event(&self, addr: SocketAddr, event: GossipEvent, seen: HashSet<SocketAddr>) {
-        debug!(target: &self.own_addr.to_string(), "Gossiping member event {} {:?} {:?}", addr.to_string(), event, seen);
+        debug!(target: &self.own_addr.to_string(), "Gossiping member event {} {:?} {:?}", addr, event, seen);
         let random_members = self.choose_random_members(3, &seen);
 
         let gossip_message = GossipMessage { event, addr, seen };
@@ -114,7 +114,7 @@ impl Gossip {
         self.members
             .iter()
             .filter(|(addr, _)| !except.contains(addr))
-            .choose_multiple(&mut rng, amount)
+            .sample(&mut rng, amount)
             .into_iter()
             .map(|(socket_addr, network_interface)| {
                 RemoteAddr::new_connector(*socket_addr, Some(network_interface.clone()))
@@ -213,7 +213,7 @@ impl Gossip {
     }
 
     fn share_info_with_joining_member(&self, node: Node) {
-        debug!(target: &self.own_addr.to_string(), "Sharing info with joining member {}", node.socket_addr.to_string());
+        debug!(target: &self.own_addr.to_string(), "Sharing info with joining member {}", node.socket_addr);
         node.get_remote_addr(CONNECTOR.to_string())
             .do_send(GossipJoining {
                 about_to_join: self.members.len(),

--- a/src/cluster/connector/mod.rs
+++ b/src/cluster/connector/mod.rs
@@ -16,16 +16,11 @@ pub mod single_seed;
 #[cfg(test)]
 mod tests;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Default)]
 pub enum ConnectionProtocol {
     SingleSeed,
+    #[default]
     Gossip,
-}
-
-impl Default for ConnectionProtocol {
-    fn default() -> Self {
-        Self::Gossip
-    }
 }
 
 #[derive(RemoteActor)]

--- a/src/cluster/connector/single_seed.rs
+++ b/src/cluster/connector/single_seed.rs
@@ -1,4 +1,4 @@
-use super::{messages::SingleSeedMembers, ConnectorVariant};
+use super::{ConnectorVariant, messages::SingleSeedMembers};
 use crate::{
     Cluster, ConnectToNode, CustomSystemService, NetworkInterface, Node, NodeEvent, RemoteAddr,
 };
@@ -35,12 +35,12 @@ impl SingleSeed {
     fn add_member(&mut self, node: &Node) {
         self.members
             .insert(node.socket_addr, node.clone().network_interface.unwrap());
-        debug!(target: &self.own_addr.to_string(), "Member {} added!", node.socket_addr.to_string());
+        debug!(target: &self.own_addr.to_string(), "Member {} added!", node.socket_addr);
     }
 
     fn remove_member(&mut self, addr: SocketAddr) {
         self.members.remove(&addr);
-        debug!("Member {} removed", addr.to_string());
+        debug!("Member {} removed", addr);
     }
 
     fn give_information(&mut self, member_addr: SocketAddr) {

--- a/src/cluster/connector/tests.rs
+++ b/src/cluster/connector/tests.rs
@@ -4,7 +4,7 @@ use actix_rt::System;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 
 use crate::{
-    test_utils::get_n_local_socket_addrs, Cluster, Connector, CustomSystemService, NodeResolving,
+    Cluster, Connector, CustomSystemService, NodeResolving, test_utils::get_n_local_socket_addrs,
 };
 
 const FAILED_TO_RESOLVE_NODES: &str = "Failed to resolve nodes";

--- a/src/cluster/mod.rs
+++ b/src/cluster/mod.rs
@@ -7,15 +7,15 @@ pub use self::listener::{ClusterListener, ClusterLog};
 pub use connector::NodeResolving;
 pub use connector::{gossip::Gossip, single_seed::SingleSeed};
 
+use crate::CustomSystemService;
 pub use crate::cluster::connector::ConnectionProtocol;
 pub use crate::cluster::connector::Connector;
 use crate::network::NetworkInterface;
 use crate::remote::Node;
-use crate::CustomSystemService;
 use actix::prelude::*;
 use actix_broker::BrokerIssue;
-use futures::executor::block_on;
 use futures::StreamExt;
+use futures::executor::block_on;
 use log::*;
 use std::collections::HashMap;
 use std::fmt::Display;
@@ -94,7 +94,7 @@ impl Actor for Cluster {
         for node_addr in 0..addrs_len {
             self.add_node(*self.addrs.get(node_addr).unwrap(), true);
         }
-        debug!("Cluster started {}", self.ip_address.clone().to_string());
+        debug!("Cluster started {}", self.ip_address);
     }
 }
 

--- a/src/cluster/tests.rs
+++ b/src/cluster/tests.rs
@@ -11,7 +11,7 @@ use port_scanner::{local_port_available, request_open_port};
 use rayon::prelude::*;
 use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
-use tokio::time::{sleep, Duration};
+use tokio::time::{Duration, sleep};
 
 type SocketTestClusterListener = TestClusterListener<Arc<Mutex<Vec<SocketAddr>>>>;
 
@@ -116,14 +116,18 @@ async fn cluster_adds_node_and_from_stream() {
     )
     .start();
     sleep(Duration::from_secs(1)).await;
-    assert!(connections
-        .lock()
-        .unwrap()
-        .contains(&("127.0.0.1:1993".parse().unwrap())));
-    assert!(connections
-        .lock()
-        .unwrap()
-        .contains(&("127.0.0.1:1992".parse().unwrap())));
+    assert!(
+        connections
+            .lock()
+            .unwrap()
+            .contains(&("127.0.0.1:1993".parse().unwrap()))
+    );
+    assert!(
+        connections
+            .lock()
+            .unwrap()
+            .contains(&("127.0.0.1:1992".parse().unwrap()))
+    );
 }
 
 // Gossip

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -33,7 +33,7 @@ impl ClusterMessage {
 
     pub fn set_buffer(&mut self, bytes: Vec<u8>) {
         match self {
-            Self::Message(ref mut wrapper) => wrapper.message_buffer = bytes,
+            Self::Message(wrapper) => wrapper.message_buffer = bytes,
             _ => panic!("set_buffer should not be used if not ClusterMessage::Message"),
         }
     }
@@ -62,7 +62,7 @@ impl Decoder for ConnectCodec {
                 let _s = src.split_to(11);
                 self.prefix = true;
             } else {
-                return Err(io::Error::new(io::ErrorKind::Other, "Prefix mismatch"));
+                return Err(io::Error::other("Prefix mismatch"));
             }
         }
 

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -7,12 +7,12 @@ use std::io::Error;
 use std::net::SocketAddr;
 use tokio::net::TcpStream;
 
+use crate::Node;
 use crate::cluster::{Cluster, NodeEvent};
 use crate::codec::{ClusterMessage, ConnectCodec};
 use crate::network::resolver::{Connect, Resolver};
 use crate::network::writer::Writer;
 use crate::remote::{AddrRepresentation, AddrResolver, RemoteWrapper};
-use crate::Node;
 use crate::{ConnectionApproval, ConnectionApprovalResponse, Connector, CustomSystemService};
 use actix::io::WriteHandler;
 use std::fmt;
@@ -104,10 +104,7 @@ impl NetworkInterface {
             .map(|res, act, ctx| match res {
                 Ok(stream) => {
                     if let Ok(stream) = stream {
-                        debug!(
-                            "Connected to network node: {}",
-                            act.addr.clone().to_string()
-                        );
+                        debug!("Connected to network node: {}", act.addr);
 
                         let (r, w) = stream.into_split();
 
@@ -126,7 +123,7 @@ impl NetworkInterface {
                     }
                 }
                 Err(err) => {
-                    error!("{} | {}", err.to_string(), act.addr.to_string());
+                    error!("{} | {}", err, act.addr);
                     act.counter += 1;
                     sleep(Duration::from_secs(1));
                     ctx.stop();
@@ -140,7 +137,7 @@ impl NetworkInterface {
 
         match self.own_addr.clone() {
             Some(addr) => {
-                debug!(target: &self.own_ip.to_string(), "finish connecting to {}", self.addr.to_string());
+                debug!(target: &self.own_ip.to_string(), "finish connecting to {}", self.addr);
                 let node = Node::new(self.addr, Some(addr));
                 Cluster::from_custom_registry().do_send(NodeEvent::MemberUp(node, self_is_seed));
             }

--- a/src/network/resolver.rs
+++ b/src/network/resolver.rs
@@ -14,11 +14,12 @@ use tokio::net::TcpStream;
 
 use actix::prelude::*;
 use futures::prelude::future::Either;
-use tokio::time::{sleep, Sleep};
-use trust_dns_resolver::config::{ResolverConfig, ResolverOpts};
-use trust_dns_resolver::error::ResolveError;
-use trust_dns_resolver::lookup_ip::LookupIp;
-use trust_dns_resolver::TokioAsyncResolver as AsyncResolver;
+use hickory_resolver::ResolveError;
+use hickory_resolver::TokioResolver as AsyncResolver;
+use hickory_resolver::config::{ResolverConfig, ResolverOpts};
+use hickory_resolver::lookup_ip::LookupIp;
+use hickory_resolver::name_server::TokioConnectionProvider;
+use tokio::time::{Sleep, sleep};
 
 #[derive(Eq, PartialEq, Debug)]
 pub struct Resolve {
@@ -61,19 +62,19 @@ impl Message for ConnectAddr {
 #[derive(Debug, Display)]
 pub enum ResolverError {
     /// Failed to resolve the hostname
-    #[display(fmt = "Failed resolving hostname: {}", _0)]
+    #[display("Failed resolving hostname: {}", _0)]
     Resolver(String),
 
     /// Address is invalid
-    #[display(fmt = "Invalid input: {}", _0)]
+    #[display("Invalid input: {}", _0)]
     InvalidInput(&'static str),
 
     /// Connecting took too long
-    #[display(fmt = "Timeout out while establishing connection")]
+    #[display("Timeout out while establishing connection")]
     Timeout,
 
     /// Connection io error
-    #[display(fmt = "{}", _0)]
+    #[display("{}", _0)]
     IoError(io::Error),
 }
 
@@ -95,19 +96,28 @@ impl Actor for Resolver {
                     |cfg, this, _| -> Pin<Box<dyn ActorFuture<Self, Output = _>>> {
                         if let Some(cfg) = cfg {
                             return Box::pin(
-                                async { AsyncResolver::tokio(cfg.0, cfg.1) }.into_actor(this),
+                                async move {
+                                    AsyncResolver::builder_with_config(
+                                        cfg.0,
+                                        TokioConnectionProvider::default(),
+                                    )
+                                    .with_options(cfg.1)
+                                    .build()
+                                }
+                                .into_actor(this),
                             );
                         }
                         Box::pin(
                             async {
-                                match AsyncResolver::tokio_from_system_conf() {
-                                    Ok(resolver) => resolver,
+                                match AsyncResolver::builder_tokio() {
+                                    Ok(builder) => builder.build(),
                                     Err(err) => {
                                         warn!("Can not create system dns resolver: {}", err);
-                                        AsyncResolver::tokio(
+                                        AsyncResolver::builder_with_config(
                                             ResolverConfig::default(),
-                                            ResolverOpts::default(),
+                                            TokioConnectionProvider::default(),
                                         )
+                                        .build()
                                     }
                                 }
                             }

--- a/src/network/writer.rs
+++ b/src/network/writer.rs
@@ -1,5 +1,5 @@
-use crate::codec::ConnectCodec;
 use crate::ClusterMessage;
+use crate::codec::ConnectCodec;
 use actix::io::{FramedWrite, WriteHandler};
 use actix::prelude::*;
 use std::io::Error;

--- a/src/remote/addr/resolver.rs
+++ b/src/remote/addr/resolver.rs
@@ -3,7 +3,7 @@ use actix::prelude::*;
 use log::*;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::fmt::{Debug, Formatter};
+use std::fmt::{self, Debug, Display, Formatter};
 use std::hash::{Hash, Hasher};
 use std::str::FromStr;
 
@@ -17,12 +17,12 @@ pub enum AddrRepresentation {
     Key(String),
 }
 
-impl ToString for AddrRepresentation {
-    fn to_string(&self) -> String {
+impl Display for AddrRepresentation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            AddrRepresentation::NetworkInterface => String::from(NETWORKINTERFACE),
-            AddrRepresentation::Connector => String::from(GOSSIP),
-            AddrRepresentation::Key(id) => id.clone(),
+            AddrRepresentation::NetworkInterface => f.write_str(NETWORKINTERFACE),
+            AddrRepresentation::Connector => f.write_str(GOSSIP),
+            AddrRepresentation::Key(id) => f.write_str(id),
         }
     }
 }
@@ -153,7 +153,10 @@ impl Handler<RemoteWrapper> for AddrResolver {
         {
             recipient.do_send(msg);
         } else {
-            warn!("Could not resolve Recipient '{}' for RemoteMessage. Is this receiver a RemoteActor? Message is abandoned.", msg.identifier);
+            warn!(
+                "Could not resolve Recipient '{}' for RemoteMessage. Is this receiver a RemoteActor? Message is abandoned.",
+                msg.identifier
+            );
         }
     }
 }
@@ -164,7 +167,7 @@ impl Handler<AddrRequest> for AddrResolver {
     fn handle(&mut self, msg: AddrRequest, _ctx: &mut Context<Self>) -> Self::Result {
         match msg {
             AddrRequest::Register(rec, identifier) => {
-                let is_new = self.rec2str.get(&rec).is_none();
+                let is_new = !self.rec2str.contains_key(&rec);
 
                 if is_new {
                     self.str2rec.insert(identifier.clone(), rec.clone());

--- a/src/remote/addr/tests.rs
+++ b/src/remote/addr/tests.rs
@@ -1,5 +1,5 @@
-use crate::{prelude::*, Node};
 use crate::{AddrRepresentation, AddrRequest, AddrResolver, AddrResponse};
+use crate::{Node, prelude::*};
 use actix::prelude::*;
 use actix_broker::BrokerSubscribe;
 use actix_telepathy_derive::{RemoteActor, RemoteMessage};

--- a/src/serialization/mod.rs
+++ b/src/serialization/mod.rs
@@ -50,7 +50,7 @@ pub trait CustomSerialization {
         T: ?Sized + Serialize;
     fn deserialize<'a, T>(&self, s: &'a [u8]) -> Result<T, CustomSerializationError>
     where
-        T: ?Sized + Deserialize<'a>;
+        T: Deserialize<'a>;
 }
 
 /// Occurs if either the serialization or the deserialization fails for the `CustomSerialization`
@@ -87,7 +87,7 @@ impl CustomSerialization for DefaultSerialization {
 
     fn deserialize<'a, T>(&self, s: &'a [u8]) -> Result<T, CustomSerializationError>
     where
-        T: ?Sized + Deserialize<'a>,
+        T: Deserialize<'a>,
     {
         match flexbuffers::from_slice(s) {
             Ok(val) => Ok(val),

--- a/src/utils/custom_system_service.rs
+++ b/src/utils/custom_system_service.rs
@@ -61,10 +61,10 @@ pub trait CustomSystemService: Actor<Context = Context<Self>> + SystemService {
             .entry(sys.id())
             .or_insert_with(|| PatchedSystemRegistry::new(sys.arbiter().clone()));
 
-        if let Some(addr) = reg.registry.get(&TypeId::of::<Self>()) {
-            if let Some(addr) = addr.downcast_ref::<Addr<Self>>() {
-                return addr.clone();
-            }
+        if let Some(addr) = reg.registry.get(&TypeId::of::<Self>())
+            && let Some(addr) = addr.downcast_ref::<Addr<Self>>()
+        {
+            return addr.clone();
         }
 
         panic!("Please start Actor before asking for it in registry!");


### PR DESCRIPTION
- Bump bytes to 1.11.1, rand to 0.10.0, flexbuffers to 25.12.19, derive_more to 2.1.1 (with full features)
- Update derive_more display attribute syntax to remove fmt= prefix
- Replace deprecated choose_multiple with sample in gossip connector
- Remove unused ndarray optional dependency
- Update version to 0.6.2 in Cargo.toml and README